### PR TITLE
fix: support database route tables in scaffold

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -36,12 +36,14 @@ variables:
     confirm: true
   - name: vpc_subnets
     order: 4
-    description: "VPC Subnets scope, required if vpc_enabled is true, options: private, intra"
+    description: "VPC Subnets scope, required if vpc_enabled is true, options: private, intra, database, database,private"
     type: enum
-    default: intra
-    allowed_values:
+    default: database,private
+    options:
       - private
       - intra
+      - database
+      - database,private
     confirm: true
   - name: tgw_enabled
     order: 5

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -46,6 +46,10 @@ dependency "vpc" {
       "rtb-1234567896",
       "rtb-1234567897",
     ]
+    database_route_table_ids = [
+      "rtb-1234567898",
+      "rtb-1234567899",
+    ]
   }
 }
 {{ end }}
@@ -99,7 +103,7 @@ inputs = {
   {{- range .optionalVariables }}
   {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
   {{- if and $.vpc_enabled (eq .Name "vpc_route_table_ids") }}
-  vpc_route_table_ids = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.public_route_table_ids, dependency.vpc.outputs.intra_route_table_ids)
+  vpc_route_table_ids = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.public_route_table_ids, dependency.vpc.outputs.intra_route_table_ids, dependency.vpc.outputs.database_route_table_ids)
   {{- else if and $.tgw_enabled (eq .Name "transit_gateway_route_table_id") }}
   {{ .Name }} = dependency.tgw.outputs.{{ .Name }}
   {{- else if and $.tgw_att_enabled (eq .Name "transit_gateway_attachment_id") }}

--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.id)
+  region_arr        = split("-", data.aws_region.current.region) # id & name are deprecated from v6.47.0, use region instead
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)


### PR DESCRIPTION
## Summary

- Add database route table mock outputs for scaffold validation
- Include database route tables in generated VPC route table inputs
- Align VPC subnet prompt default with enum options
- Replace deprecated AWS region data source attribute usage

+semver: patch