### PR TITLE
fix: improve vpc_subnets scaffold options with both/none cases

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -36,14 +36,15 @@ variables:
     confirm: true
   - name: vpc_subnets
     order: 4
-    description: "VPC Subnets scope, required if vpc_enabled is true, options: private, intra, database, database,private"
+    description: "VPC Subnets scope, required if vpc_enabled is true, options: intra, private, database, both(database,private), none"
     type: enum
-    default: database,private
+    default: both
     options:
-      - private
       - intra
+      - private
       - database
-      - database,private
+      - both
+      - none
     confirm: true
   - name: tgw_enabled
     order: 5

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -103,7 +103,13 @@ inputs = {
   {{- range .optionalVariables }}
   {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
   {{- if and $.vpc_enabled (eq .Name "vpc_route_table_ids") }}
-  vpc_route_table_ids = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.public_route_table_ids, dependency.vpc.outputs.intra_route_table_ids, dependency.vpc.outputs.database_route_table_ids)
+  {{- if eq .vpc_subnets "both" }}
+  vpc_route_table_ids = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.database_route_table_ids)
+  {{- else if eq .vpc_subnets "none" }}
+  vpc_route_table_ids = []
+  {{- else }}
+  vpc_route_table_ids = dependency.vpc.outputs.{{ .vpc_subnets }}_route_table_ids
+  {{- end }}
   {{- else if and $.tgw_enabled (eq .Name "transit_gateway_route_table_id") }}
   {{ .Name }} = dependency.tgw.outputs.{{ .Name }}
   {{- else if and $.tgw_att_enabled (eq .Name "transit_gateway_attachment_id") }}


### PR DESCRIPTION
## Summary

- Replace `database,private` enum option with `both` for clarity and correctness
- Add `none` option to support deployments with no VPC subnet routes
- Update terragrunt.hcl template logic to handle both/none/single-subnet cases for `vpc_route_table_ids`
- Improve `vpc_subnets` description to document all valid options

+semver: patch