### PR TITLE
fix: support TGW route table source selection

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -58,14 +58,23 @@ variables:
     type: string
     default: "../tgw"
     confirm: true
-  - name: tgw_att_enabled
+  - name: tgw_route_table_source
     order: 7
+    description: "Select TGW dependency output to use for transit_gateway_route_table_id, required if tgw_enabled is true"
+    type: enum
+    default: route-table
+    options:
+      - route-table
+      - propagation-default
+    confirm: true
+  - name: tgw_att_enabled
+    order: 8
     description: "Enable TGW Attachment Module dependency"
     type: bool
     default: true
     confirm: true
   - name: tgw_att_path
-    order: 8
+    order: 9
     description: "Path to TGW Attachment Module, required if tgw_att_enabled is true"
     type: string
     default: "../tgw-att"

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -60,9 +60,10 @@ dependency "tgw" {
   # module hasn't been applied yet.
   mock_outputs_allowed_terraform_commands = ["validate", "destroy"]
   mock_outputs = {
-    transit_gateway_arn            = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234",
-    transit_gateway_id             = "tgw-12345678901234"
-    transit_gateway_route_table_id = "tgw-rtb-12345678901234"
+    transit_gateway_arn                                = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234",
+    transit_gateway_id                                 = "tgw-12345678901234"
+    transit_gateway_route_table_id                     = "tgw-rtb-11111111111111111"
+    transit_gateway_propagation_default_route_table_id = "tgw-rtb-22222222222222222"
   }
 }
 {{ end }}
@@ -111,7 +112,11 @@ inputs = {
   vpc_route_table_ids = dependency.vpc.outputs.{{ $.vpc_subnets }}_route_table_ids
   {{- end }}
   {{- else if and $.tgw_enabled (eq .Name "transit_gateway_route_table_id") }}
-  {{ .Name }} = dependency.tgw.outputs.{{ .Name }}
+  {{- if eq $.tgw_route_table_source "propagation-default" }}
+  {{ .Name }} = dependency.tgw.outputs.transit_gateway_propagation_default_route_table_id
+  {{- else }}
+  {{ .Name }} = dependency.tgw.outputs.transit_gateway_route_table_id
+  {{- end }}
   {{- else if and $.tgw_att_enabled (eq .Name "transit_gateway_attachment_id") }}
   {{ .Name }} = dependency.att.outputs.transit_gateway_attachments[0].id
   {{- else}}

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ create_propagation: false # (Optional) Create a Transit Gateway route table prop
 replace_existing: false # (Optional) Replace an existing Transit Gateway route table association when create_association is true. Default: false
 ```
 
+When scaffold prompts for the Transit Gateway route table source, keep the default `route-table` value to use the TGW
+module's route table output, or choose `propagation-default` to wire the propagation default route table output
+into `transit_gateway_route_table_id`.
+
 With the default scaffold options, the generated `terragrunt.hcl` wires VPC, Transit Gateway, and attachment
 dependencies into module inputs while keeping deployment-specific overrides in `inputs.yaml`:
 
@@ -151,6 +155,10 @@ dependency "vpc" {
       "rtb-1234567896",
       "rtb-1234567897",
     ]
+    database_route_table_ids = [
+      "rtb-1234567898",
+      "rtb-1234567899",
+    ]
   }
 }
 
@@ -158,9 +166,10 @@ dependency "tgw" {
   config_path = "../tgw"
   mock_outputs_allowed_terraform_commands = ["validate", "destroy"]
   mock_outputs = {
-    transit_gateway_arn            = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234"
-    transit_gateway_id             = "tgw-12345678901234"
-    transit_gateway_route_table_id = "tgw-rtb-12345678901234"
+    transit_gateway_arn                                = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234"
+    transit_gateway_id                                 = "tgw-12345678901234"
+    transit_gateway_route_table_id                     = "tgw-rtb-11111111111111111"
+    transit_gateway_propagation_default_route_table_id = "tgw-rtb-22222222222222222"
   }
 }
 
@@ -188,7 +197,7 @@ inputs = {
   spoke_def = local.spoke_vars.spoke
 
   transit_gateway_id             = dependency.tgw.outputs.transit_gateway_id
-  vpc_route_table_ids            = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.public_route_table_ids, dependency.vpc.outputs.intra_route_table_ids)
+  vpc_route_table_ids            = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.database_route_table_ids)
   tgw_destination_cidr           = try(local.local_vars.tgw_destination_cidr, "")
   ipv6_support                   = try(local.local_vars.ipv6_support, false)
   transit_gateway_route_table_id = dependency.tgw.outputs.transit_gateway_route_table_id
@@ -263,6 +272,17 @@ inputs = {
 }
 ```
 
+### Scaffolded Propagation Default Route Table
+When a deployment should use the Transit Gateway module's propagation default route table, choose
+`propagation-default` for the scaffold prompt `tgw_route_table_source`. The rendered input is wired from the TGW
+dependency output:
+
+```hcl
+inputs = {
+  transit_gateway_route_table_id = dependency.tgw.outputs.transit_gateway_propagation_default_route_table_id
+}
+```
+
 ### IPv6 VPC Route Table Updates
 Add IPv6 routes to selected VPC route tables by setting `ipv6_support` to true and using an IPv6 destination CIDR.
 
@@ -300,7 +320,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -74,6 +74,10 @@ usage: |-
   replace_existing: false # (Optional) Replace an existing Transit Gateway route table association when create_association is true. Default: false
   ```
 
+  When scaffold prompts for the Transit Gateway route table source, keep the default `route-table` value to use the TGW
+  module's route table output, or choose `propagation-default` to wire the propagation default route table output
+  into `transit_gateway_route_table_id`.
+
   With the default scaffold options, the generated `terragrunt.hcl` wires VPC, Transit Gateway, and attachment
   dependencies into module inputs while keeping deployment-specific overrides in `inputs.yaml`:
 
@@ -124,6 +128,10 @@ usage: |-
         "rtb-1234567896",
         "rtb-1234567897",
       ]
+      database_route_table_ids = [
+        "rtb-1234567898",
+        "rtb-1234567899",
+      ]
     }
   }
 
@@ -131,9 +139,10 @@ usage: |-
     config_path = "../tgw"
     mock_outputs_allowed_terraform_commands = ["validate", "destroy"]
     mock_outputs = {
-      transit_gateway_arn            = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234"
-      transit_gateway_id             = "tgw-12345678901234"
-      transit_gateway_route_table_id = "tgw-rtb-12345678901234"
+      transit_gateway_arn                                = "arn:aws:ec2:us-west-2:551110472991:transit-gateway/tgw-12345678901234"
+      transit_gateway_id                                 = "tgw-12345678901234"
+      transit_gateway_route_table_id                     = "tgw-rtb-11111111111111111"
+      transit_gateway_propagation_default_route_table_id = "tgw-rtb-22222222222222222"
     }
   }
 
@@ -161,7 +170,7 @@ usage: |-
     spoke_def = local.spoke_vars.spoke
 
     transit_gateway_id             = dependency.tgw.outputs.transit_gateway_id
-    vpc_route_table_ids            = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.public_route_table_ids, dependency.vpc.outputs.intra_route_table_ids)
+    vpc_route_table_ids            = concat(dependency.vpc.outputs.private_route_table_ids, dependency.vpc.outputs.database_route_table_ids)
     tgw_destination_cidr           = try(local.local_vars.tgw_destination_cidr, "")
     ipv6_support                   = try(local.local_vars.ipv6_support, false)
     transit_gateway_route_table_id = dependency.tgw.outputs.transit_gateway_route_table_id
@@ -224,6 +233,17 @@ examples: |-
     vpc_route_table_ids  = dependency.vpc.outputs.private_route_table_ids
     tgw_destination_cidr = "10.0.0.0/8"
     ipv6_support         = false
+  }
+  ```
+
+  ### Scaffolded Propagation Default Route Table
+  When a deployment should use the Transit Gateway module's propagation default route table, choose
+  `propagation-default` for the scaffold prompt `tgw_route_table_source`. The rendered input is wired from the TGW
+  dependency output:
+
+  ```hcl
+  inputs = {
+    transit_gateway_route_table_id = dependency.tgw.outputs.transit_gateway_propagation_default_route_table_id
   }
   ```
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -9,7 +9,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
 
 ## Modules
 


### PR DESCRIPTION
## Summary

- Add a scaffold selector for the Transit Gateway route table dependency output
- Wire propagation default route table output when selected
- Keep route-table output as the default scaffold behavior
- Document the scaffold option and refresh generated Terraform docs

+semver: patch

## Validation

- `git diff --check`
- YAML parse for `.boilerplate/boilerplate.yml`
- Rendered scaffold template variants for `route-table`, `propagation-default`, and `tgw_enabled=false`
- Verified upstream `cloudopsworks/terraform-module-aws-transit-gateway` latest release `v2.0.3` exports `transit_gateway_propagation_default_route_table_id`
- `make fmt && make lint`